### PR TITLE
feat(procfs): add ABI gaps

### DIFF
--- a/kernel/abi_gaps.c
+++ b/kernel/abi_gaps.c
@@ -1,0 +1,49 @@
+#include <stddef.h>
+#include <stdint.h>
+
+#include "include/abi_gaps.h"
+#include "include/kstring.h"
+#include "include/process.h"
+
+static struct abi_gap gaps[ABI_GAP_SLOTS];
+static uint64_t overflow;
+
+void abi_gaps_note(uint64_t syscall_number) {
+    unsigned free_slot = ABI_GAP_SLOTS;
+    for (unsigned index = 0; index < ABI_GAP_SLOTS; index++) {
+        if (gaps[index].count && gaps[index].syscall_number == syscall_number) {
+            free_slot = index;
+            break;
+        }
+        if (!gaps[index].count && free_slot == ABI_GAP_SLOTS) free_slot = index;
+    }
+    if (free_slot == ABI_GAP_SLOTS) {
+        overflow++;
+        return;
+    }
+
+    struct abi_gap *gap = &gaps[free_slot];
+    if (!gap->count) gap->syscall_number = syscall_number;
+    gap->count++;
+
+    struct process *process = process_current();
+    gap->last_pid = process ? process->tgid : 0;
+    strncpy(gap->last_name, process && process->name[0] ? process->name : "?",
+            sizeof(gap->last_name));
+    gap->last_name[sizeof(gap->last_name) - 1] = '\0';
+}
+
+int abi_gaps_snapshot(unsigned index, struct abi_gap *out) {
+    if (!out || index >= ABI_GAP_SLOTS || !gaps[index].count) return -1;
+    *out = gaps[index];
+    return 0;
+}
+
+uint64_t abi_gaps_overflow(void) {
+    return overflow;
+}
+
+void abi_gaps_clear(void) {
+    memset(gaps, 0, sizeof(gaps));
+    overflow = 0;
+}

--- a/kernel/fs/procfs.c
+++ b/kernel/fs/procfs.c
@@ -1,5 +1,6 @@
 #include <stddef.h>
 #include <stdint.h>
+#include "../include/abi_gaps.h"
 #include "../include/ext2.h"
 #include "../include/heap.h"
 #include "../include/irq.h"
@@ -238,6 +239,46 @@ static int64_t proc_klock_write(struct vfs_node *node, uint64_t offset,
     const char *text = (const char *)input;
     if (size && text && text[0] == '0') klock_statistics_stop();
     else klock_statistics_start();
+    return (int64_t)size;
+}
+
+/* Report missing syscall use. */
+static int64_t proc_abi_gaps_read(struct vfs_node *node, uint64_t offset,
+                                  size_t size, void *output) {
+    (void)node;
+    struct text_buffer text = {{0}, 0};
+    int found = 0;
+    for (unsigned index = 0; index < ABI_GAP_SLOTS; index++) {
+        struct abi_gap gap;
+        if (abi_gaps_snapshot(index, &gap) != 0) continue;
+        found = 1;
+        text_string(&text, "syscall ");
+        text_unsigned(&text, gap.syscall_number);
+        text_string(&text, " count ");
+        text_unsigned(&text, gap.count);
+        text_string(&text, " last ");
+        text_string(&text, gap.last_name);
+        text_char(&text, '[');
+        text_unsigned(&text, gap.last_pid);
+        text_string(&text, "]\n");
+    }
+    uint64_t overflow = abi_gaps_overflow();
+    if (overflow) {
+        found = 1;
+        text_string(&text, "overflow ");
+        text_unsigned(&text, overflow);
+        text_char(&text, '\n');
+    }
+    if (!found) text_string(&text, "none\n");
+    return text_read(&text, offset, size, output);
+}
+
+/* Clear missing syscall use. */
+static int64_t proc_abi_gaps_write(struct vfs_node *node, uint64_t offset,
+                                   size_t size, const void *input) {
+    (void)node; (void)offset;
+    const char *text = (const char *)input;
+    if (size && text && text[0] == '0') abi_gaps_clear();
     return (int64_t)size;
 }
 
@@ -858,6 +899,11 @@ void procfs_init(void) {
     virtual_file(root, "uptime", proc_uptime_read, 0);
     virtual_file(root, "blockstat", proc_blockstat_read, 0);
     virtual_file(root, "inputlog", proc_inputlog_read, 0);
+    struct vfs_node *abi_gaps = virtual_file(root, "abi_gaps", proc_abi_gaps_read, 0);
+    if (abi_gaps) {
+        abi_gaps->mode = 0644;
+        abi_gaps->write = proc_abi_gaps_write;
+    }
     struct vfs_node *klock = virtual_file(root, "klock", proc_klock_read, 0);
     if (klock) {
         klock->mode = 0644;

--- a/kernel/include/abi_gaps.h
+++ b/kernel/include/abi_gaps.h
@@ -1,0 +1,21 @@
+#ifndef TUNIX_ABI_GAPS_H
+#define TUNIX_ABI_GAPS_H
+
+#include <stdint.h>
+
+#define ABI_GAP_SLOTS 32U
+#define ABI_GAP_NAME_SIZE 32U
+
+struct abi_gap {
+    uint64_t syscall_number;
+    uint64_t count;
+    uint64_t last_pid;
+    char last_name[ABI_GAP_NAME_SIZE];
+};
+
+void abi_gaps_note(uint64_t syscall_number);
+int abi_gaps_snapshot(unsigned index, struct abi_gap *out);
+uint64_t abi_gaps_overflow(void);
+void abi_gaps_clear(void);
+
+#endif

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -1,5 +1,6 @@
 #include <stddef.h>
 #include <stdint.h>
+#include "include/abi_gaps.h"
 #include "include/cred.h"
 #include "include/file.h"
 #include "include/eventfd.h"
@@ -5778,6 +5779,7 @@ static int syscall_number_may_share(uint64_t number) {
 #define VERBOSE_SYSCALL_LIMIT 24U
 
 void syscall_dispatch(struct syscall_frame *frame) {
+    uint64_t syscall_number = frame->rax;
     klock_note(KLOCK_NOTE_SYSCALL | (uint32_t)frame->rax);
     /* The first syscall is the answer to one question and it is the question
        that matters here: whether userland ran at all. */
@@ -5807,10 +5809,12 @@ void syscall_dispatch(struct syscall_frame *frame) {
 
     kernel_lock();
     syscall_dispatch_locked(frame);
+    struct syscall_frame *resumed = frame;
     uint64_t stack_top = cpu_current()->kernel_rsp;
     if (stack_top) {
-        struct syscall_frame *resumed =
-            (struct syscall_frame *)(stack_top - sizeof(*frame));
+        resumed = (struct syscall_frame *)(stack_top - sizeof(*frame));
         if (resumed != frame) *resumed = *frame;
     }
+    if ((int64_t)resumed->rax == -(int64_t)ENOSYS)
+        abi_gaps_note(syscall_number);
 }


### PR DESCRIPTION
proc abi gaps shows missing syscalls
use cat to read and write zero to clear